### PR TITLE
FF: Add experiment settings module 

### DIFF
--- a/psychopy_eyetracker_eyelogic/eyelogic/psychopy/settings.py
+++ b/psychopy_eyetracker_eyelogic/eyelogic/psychopy/settings.py
@@ -1,0 +1,88 @@
+from psychopy.localization import _translate
+from psychopy.experiment import Param
+from psychopy.experiment.components.settings.eyetracking import EyetrackerBackend
+
+
+class EyeLogicEyetrackerBackend(EyetrackerBackend):
+    """Experiment settings for the EyeLogic eyetrackers.
+    """
+    label = 'Eyelogic (iohub)'
+    key = 'eyetracker.eyelogic.EyeTracker'
+
+    needsFullscreen = False
+    needsCalibration = False
+
+    @classmethod
+    def getParams(cls):
+        # define order
+        order = [
+            # other settings
+            "elgLicenseFile",
+            # runtime settings
+            "elgSamplingRate",
+            "elgTrackerInfront",
+            "elgTrackerBelow"
+            "elgTrackEyes",
+        ]
+
+        # other settings
+        params = {}
+
+        # path to the license file
+        params['elgLicenseFile'] = Param(
+            "",   # default value
+            valType='str',
+            inputType="file",
+            hint=_translate("Path to the license file."),
+            label=_translate("License file"),
+            categ="Eyetracking"
+        )
+
+        # runtime settings
+        params['elgSamplingRate'] = Param(
+            60,   # default value
+            valType='int',
+            hint=_translate("The sampling rate of the eyetracker."),
+            label=_translate("Sampling rate (Hz)"),
+            categ="Eyetracking"
+        )
+        params['elgTrackerInfront'] = Param(
+            0.0,
+            valType='float',
+            hint=_translate("The distance of the eyetracker from the screen in front of the participant (-300.0 to 300.0 cm)."),
+            label=_translate("Distance in front (cm)"),
+            categ="Eyetracking"
+        )
+        params['elgTrackerBelow'] = Param(
+            0.0,
+            valType='float',
+            hint=_translate("The distance of the eyetracker from the screen below the participant (-300.0 to 300.0 cm)."),
+            label=_translate("Distance below (cm)"),
+            categ="Eyetracking"
+        )
+        params['elgTrackEyes'] = Param(
+            'BINOCULAR',
+            valType='str',
+            inputType='choice',
+            choices=['BINOCULAR',],
+            hint=_translate("The eyes to track."),
+            label=_translate("Track eyes"),
+            categ="Eyetracking"
+        )
+        return params, order
+
+    @classmethod
+    def writeDeviceCode(cls, inits, buff):
+        code = (
+            "ioConfig[%(eyetracker)s] = {\n"
+            "    'name': 'tracker',\n"
+            "    'license_file': %(elgLicenseFile)s,\n"
+            "    'runtime_settings': {\n"
+            "        'sampling_rate': %(elgSamplingRate)s,\n"
+            "        'tracker_infront': %(elgTrackerInfront)s,\n"
+            "        'tracker_below': %(elgTrackerBelow)s,\n"
+            "        'track_eyes': %(elgTrackEyes)s,\n"
+            "    },\n"
+            "}\n"
+        )
+        buff.writeIndentedLines(code % inits)

--- a/psychopy_eyetracker_eyelogic/eyelogic/psychopy/settings.py
+++ b/psychopy_eyetracker_eyelogic/eyelogic/psychopy/settings.py
@@ -6,7 +6,7 @@ from psychopy.experiment.components.settings.eyetracking import EyetrackerBacken
 class EyeLogicEyetrackerBackend(EyetrackerBackend):
     """Experiment settings for the EyeLogic eyetrackers.
     """
-    label = 'Eyelogic (iohub)'
+    label = 'EyeLogic (iohub)'
     key = 'eyetracker.eyelogic.EyeTracker'
 
     needsFullscreen = False
@@ -64,7 +64,7 @@ class EyeLogicEyetrackerBackend(EyetrackerBackend):
             'BINOCULAR',
             valType='str',
             inputType='choice',
-            choices=['BINOCULAR',],
+            allowedVals=['BINOCULAR',],
             hint=_translate("The eyes to track."),
             label=_translate("Track eyes"),
             categ="Eyetracking"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "psychopy-eyetracker-eyelogic"
-version = "1.1.13"
+version = "1.1.14"
 description = "extension package for PsychoPy which adds support for EyeLogic eyetrackers to ioHub"
 readme = "README.md"
 requires-python = ">= 3.7"
@@ -36,3 +36,6 @@ include = ["psychopy_eyetracker_eyelogic*"]
 
 [project.entry-points."psychopy.iohub.devices.eyetracker"]
 eyelogic = "psychopy_eyetracker_eyelogic.eyelogic"
+
+[project.entry-points."psychopy.experiment.components.settings.eyetracking"]
+EyeLogicEyetrackerBackend = "psychopy_eyetracker_eyelogic.eyelogic.psychopy.settings.EyeLogicEyetrackerBackend"


### PR DESCRIPTION
PsychoPy updated how eyetracker settings are obtained, now using the `EyetrackerBackend` class that must be defined and given an entry point into `psychopy.experiment.component.settings.eyetracking` module.

The class instructs how to build the dialog and how to generate the configuration string for iohub in the code output.